### PR TITLE
build(front): download dependencies separately

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,11 +2,13 @@ FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
-COPY . /app
-WORKDIR /app
 
 FROM base AS build
+WORKDIR /app
+COPY package.json .
+COPY pnpm-lock.yaml .
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+COPY . /app
 RUN pnpm run build
 
 FROM nginx:1.26.0-alpine


### PR DESCRIPTION
Previously, Docker signatures for frontend were always different, even though they contained the same files. Suppousedly, this PR should fix that.

### Example
![image](https://github.com/FEgor04/physics-circuits-simulation/assets/20701544/b9861f01-44ed-4118-8b1d-b716041ccfc3)
Backend images on v0.8.5 and v0.8.6 are the same, their signatures are equal but tags are different.

![image](https://github.com/FEgor04/physics-circuits-simulation/assets/20701544/eae0db21-3143-48db-bb4b-ed7f18ae752e)
Frontend wasn't changed on v0.8.8 and v0.8.7, however Docker images have different signatures