### PR TITLE
feat: block navigation from simulation page if dirty

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.4.2",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.4.2
         version: 3.4.2(react-hook-form@7.51.5(react@18.3.1))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.0.5
+        version: 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-avatar':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -900,6 +903,19 @@ packages:
 
   '@radix-ui/primitive@1.0.1':
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
+
+  '@radix-ui/react-alert-dialog@1.0.5':
+    resolution: {integrity: sha512-OrVIOcZL0tl6xibeuGt5/+UxoT2N27KCFOPjFyfXMnchxSHZ/OW7cCX2nGlIYJrbHK/fczPcFzAwvNBB6XBNMA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.0.3':
     resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
@@ -4949,6 +4965,21 @@ snapshots:
   '@radix-ui/primitive@1.0.1':
     dependencies:
       '@babel/runtime': 7.24.6
+
+  '@radix-ui/react-alert-dialog@1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/frontend/src/pages/simulation/model/state.ts
+++ b/frontend/src/pages/simulation/model/state.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
+import { useIsArrayDirty } from "@/shared/lib/is-dirty";
 import { schemaErrors } from "@/shared/simulation/errors";
-import { pointsEqual } from "@/shared/simulation/lib";
+import { componentsEqual, pointsEqual } from "@/shared/simulation/lib";
 import { SimpleSimulator } from "@/shared/simulation/simulator";
 import {
   ElectricalComponent,
@@ -19,11 +20,12 @@ type SimulationState = {
   onDeleteComponent: (id: ElectricalComponentID) => void;
   simulator: SimpleSimulator;
   errors: keyof typeof schemaErrors | undefined;
-  isDirty: boolean
+  isDirty: boolean;
 };
 
 export function useSimulationState(components: Array<ElectricalComponentWithID>): SimulationState {
   const [schema, setSchema] = useState(components);
+  const isDirty = useIsArrayDirty(schema, components, componentsEqual);
   const simulator = useMemo(() => {
     return new SimpleSimulator(schema);
   }, [schema]);
@@ -34,7 +36,7 @@ export function useSimulationState(components: Array<ElectricalComponentWithID>)
     errors,
     simulator,
     components: schema,
-    isDirty: true,
+    isDirty,
     onAddComponent: function (newComponent: ElectricalComponent): ElectricalComponentWithID {
       let id = -1;
       setSchema((old) => {

--- a/frontend/src/pages/simulation/model/state.ts
+++ b/frontend/src/pages/simulation/model/state.ts
@@ -19,6 +19,7 @@ type SimulationState = {
   onDeleteComponent: (id: ElectricalComponentID) => void;
   simulator: SimpleSimulator;
   errors: keyof typeof schemaErrors | undefined;
+  isDirty: boolean
 };
 
 export function useSimulationState(components: Array<ElectricalComponentWithID>): SimulationState {
@@ -33,6 +34,7 @@ export function useSimulationState(components: Array<ElectricalComponentWithID>)
     errors,
     simulator,
     components: schema,
+    isDirty: true,
     onAddComponent: function (newComponent: ElectricalComponent): ElectricalComponentWithID {
       let id = -1;
       setSchema((old) => {

--- a/frontend/src/pages/simulation/tests/isDirty.test.ts
+++ b/frontend/src/pages/simulation/tests/isDirty.test.ts
@@ -1,0 +1,19 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSimulationState } from "../model/state";
+
+const setup = () => {
+  const { result, ...utils } = renderHook(() => useSimulationState([]));
+  return { result, ...utils };
+};
+
+describe("isDirty property", () => {
+  it("is true if scheme was changed", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.onAddComponent({ _type: "wire", a: { x: 0, y: 0 }, b: { x: 1, y: 1 } });
+    });
+    expect(result.current.components).toHaveLength(1);
+    expect(result.current.isDirty).toStrictEqual(true);
+  });
+});

--- a/frontend/src/pages/simulation/tests/isDirty.test.ts
+++ b/frontend/src/pages/simulation/tests/isDirty.test.ts
@@ -8,12 +8,25 @@ const setup = () => {
 };
 
 describe("isDirty property", () => {
-  it("is true if scheme was changed", () => {
+  it("is true if scheme changed", () => {
     const { result } = setup();
     act(() => {
       result.current.onAddComponent({ _type: "wire", a: { x: 0, y: 0 }, b: { x: 1, y: 1 } });
     });
     expect(result.current.components).toHaveLength(1);
     expect(result.current.isDirty).toStrictEqual(true);
+  });
+
+  it("is true if nothing has changed", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.onAddComponent({ _type: "wire", a: { x: 0, y: 0 }, b: { x: 1, y: 1 } });
+    });
+    expect(result.current.components).toHaveLength(1);
+    act(() => {
+      result.current.onDeleteComponent(1);
+    });
+    expect(result.current.components).toHaveLength(0);
+    expect(result.current.isDirty).toStrictEqual(false);
   });
 });

--- a/frontend/src/pages/simulation/ui/block.tsx
+++ b/frontend/src/pages/simulation/ui/block.tsx
@@ -1,5 +1,4 @@
 import {
-  AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,

--- a/frontend/src/pages/simulation/ui/block.tsx
+++ b/frontend/src/pages/simulation/ui/block.tsx
@@ -1,0 +1,32 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+
+type Props = {
+  reset: () => void;
+  proceed: () => void;
+};
+
+export function SimulationBlockDialog({ proceed, reset }: Props) {
+  return (
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Уверены?</AlertDialogTitle>
+        <AlertDialogDescription>
+          Вы изменили схему. Если вы покините страницу, то она не будет сохранена.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel onClick={reset}>Остаться</AlertDialogCancel>
+        <AlertDialogAction onClick={proceed}>Продолжить</AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  );
+}

--- a/frontend/src/pages/simulation/ui/index.tsx
+++ b/frontend/src/pages/simulation/ui/index.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useBlocker } from "@tanstack/react-router";
 import { RotateCcw, Save } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -15,11 +16,10 @@ import { UpdateComponentProvider } from "@/features/update-component";
 import { GetZoomCoefficientProvider } from "@/features/zoom-provider";
 import { Scheme, getSchemeByIDQueryOptions, useUpdateSchemeMutation } from "@/entities/scheme";
 import { schemaErrors } from "@/shared/simulation/errors";
+import { AlertDialog } from "@/shared/ui/alert-dialog";
 import { Button } from "@/shared/ui/button";
 import { ResizableHandle, ResizablePanelGroup } from "@/shared/ui/resizable.tsx";
 import { useSimulationState } from "../model/state";
-import { useBlocker } from "@tanstack/react-router";
-import { AlertDialog } from "@/shared/ui/alert-dialog";
 import { SimulationBlockDialog } from "./block";
 
 type Props = {

--- a/frontend/src/pages/simulation/ui/index.tsx
+++ b/frontend/src/pages/simulation/ui/index.tsx
@@ -18,6 +18,9 @@ import { schemaErrors } from "@/shared/simulation/errors";
 import { Button } from "@/shared/ui/button";
 import { ResizableHandle, ResizablePanelGroup } from "@/shared/ui/resizable.tsx";
 import { useSimulationState } from "../model/state";
+import { useBlocker } from "@tanstack/react-router";
+import { AlertDialog } from "@/shared/ui/alert-dialog";
+import { SimulationBlockDialog } from "./block";
 
 type Props = {
   mode: "simulation" | "editing";
@@ -38,7 +41,10 @@ export function Simulation({ mode, setMode, scheme: initialScheme }: Props) {
     onDeleteComponent,
     simulator,
     errors,
+    isDirty,
   } = useSimulationState(scheme.components);
+
+  const { status, proceed, reset } = useBlocker({ condition: isDirty });
 
   const { mutate, isPending } = useUpdateSchemeMutation();
 
@@ -142,6 +148,9 @@ export function Simulation({ mode, setMode, scheme: initialScheme }: Props) {
           </DeleteComponentProvider>
         </GetZoomCoefficientProvider>
       </SelectComponentProvider>
+      <AlertDialog open={status == "blocked"}>
+        <SimulationBlockDialog proceed={proceed} reset={reset} />
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/shared/lib/is-dirty.ts
+++ b/frontend/src/shared/lib/is-dirty.ts
@@ -1,0 +1,9 @@
+import { useMemo } from "react";
+
+export function useIsDirty<T>(currentValue: T, initialValue: T, isEqual: (a: T, b: T) => boolean) {
+  return useMemo(() => !isEqual(currentValue, initialValue), [currentValue, initialValue, isEqual]);
+}
+
+export function useIsArrayDirty<T>(current: Array<T>, initial: Array<T>, isEqual: (a: T, b: T) => boolean) {
+  return useIsDirty(current, initial, (a, b) => a.length == b.length && a.every((_, i) => isEqual(a[i], b[i])));
+}

--- a/frontend/src/shared/ui/alert-dialog.tsx
+++ b/frontend/src/shared/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/shared/lib"
+import { buttonVariants } from "@/shared/ui/button-variants"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}


### PR DESCRIPTION
- feat: block navigation from simulation page if simulation state is dirty (e.g. it has changed, but wasn't saved)
- feat: add `isDirty` and `isArrayDirty` hook that returns whether array / variable is the same, as it was initially
- tests: cover new feature with tests