### PR TITLE
visuals: improve auth & simulation page

### DIFF
--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -98,29 +98,45 @@
     --accent: 280 78.95% 96.27%;
     --accent-foreground: 281.96 79.27% 62.16%;
 
-    --destructive: 
-  ;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 0 0% 90.2%;
+    --input: 0 0% 90.2%;
+    --ring: 281.96 79.27% 62.16%;
+
+    --radius: 0.5rem;
   }
 
   .dark {
-    --background: 20 14.3% 4.1%;
-    --foreground: 60 9.1% 97.8%;
-    --card: 20 14.3% 4.1%;
-    --card-foreground: 60 9.1% 97.8%;
-    --popover: 20 14.3% 4.1%;
-    --popover-foreground: 60 9.1% 97.8%;
-    --primary: 20.5 90.2% 48.2%;
-    --primary-foreground: 60 9.1% 97.8%;
-    --secondary: 12 6.5% 15.1%;
-    --secondary-foreground: 60 9.1% 97.8%;
-    --muted: 12 6.5% 15.1%;
-    --muted-foreground: 24 5.4% 63.9%;
-    --accent: 12 6.5% 15.1%;
-    --accent-foreground: 60 9.1% 97.8%;
-    --destructive: 0 72.2% 50.6%;
-    --destructive-foreground: 60 9.1% 97.8%;
-    --border: 12 6.5% 15.1%;
-    --input: 12 6.5% 15.1%;
-    --ring: 20.5 90.2% 48.2%;
+    --background: 290 50% 2.35%;
+    --foreground: 281.74 79.31% 94.31%;
+
+    --primary: 281.96 79.27% 62.16%;
+    --primary-foreground: 0 0% 100%;
+
+    --card: 290 50% 2.35%;
+    --card-foreground: 281.74 79.31% 94.31%;
+
+    --popover: 290 50% 2.35%;
+    --popover-foreground: 281.74 79.31% 94.31%;
+
+    --secondary: 281.89 47.75% 21.76%;
+    --secondary-foreground: 0 0% 100%;
+
+    --muted: 290 9.68% 12.16%;
+    --muted-foreground: 300 1.2% 51.18%;
+
+    --accent: 281.89 47.75% 21.76%;
+    --accent-foreground: 281.74 79.31% 94.31%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 281.96 79.27% 62.16%;
+
+    --radius: 0.5rem;
   }
 }

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -21,7 +21,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <Toaster position="bottom-center" />
+      <Toaster position="bottom-center" richColors />
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/features/share-scheme/ui/form.tsx
+++ b/frontend/src/features/share-scheme/ui/form.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import z from "zod";
 import { SchemeID } from "@/entities/scheme";
-import { Button } from "@/shared/ui/button";
+import { PendingButton } from "@/shared/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel } from "@/shared/ui/form";
 import { Input } from "@/shared/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/shared/ui/select";
@@ -57,10 +57,14 @@ export function InviteUserForm({ schemeId }: Props) {
           if (isAxiosError(err)) {
             if (err.response?.status == 404 && err.response.data.message == "User not found") {
               toast.error("Ошибка! Нет пользователя с такой почтой", { id: toastId });
+              return;
             }
-          } else {
-            toast.error("Ошибка! " + err.message, { id: toastId });
+            if (err.response?.status == 409) {
+              toast.error("Ошибка! Вы не можете изменять собственные права", { id: toastId });
+              return;
+            }
           }
+          toast.error("Ошибка! " + err.message, { id: toastId });
         },
       },
     );
@@ -105,9 +109,9 @@ export function InviteUserForm({ schemeId }: Props) {
           )}
         />
         <FormItem>
-          <Button type="submit" disabled={isPending}>
+          <PendingButton type="submit" isPending={isPending}>
             Добавить
-          </Button>
+          </PendingButton>
         </FormItem>
       </form>
     </Form>

--- a/frontend/src/pages/signin/ui/signin.tsx
+++ b/frontend/src/pages/signin/ui/signin.tsx
@@ -1,11 +1,11 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { AxiosError } from "axios";
 import { SignInForm, useSignInByEmailMutation } from "@/features/auth-by-email";
-import { Button } from "@/shared/ui/button.tsx";
+import { Button, PendingButton } from "@/shared/ui/button.tsx";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/shared/ui/card.tsx";
 
 export function SignInPage({ redirect }: { redirect: string | undefined }) {
-  const { mutate, isError, error } = useSignInByEmailMutation();
+  const { mutate, isError, error, isPending } = useSignInByEmailMutation();
   const navigate = useNavigate({});
 
   return (
@@ -25,14 +25,20 @@ export function SignInPage({ redirect }: { redirect: string | undefined }) {
             }}
           />
         </CardContent>
-        <CardFooter className="space-x-4">
-          {isError && <ErrorMessage error={error} />}
-          <Button type="submit" form="sign-in-form">
-            Отправить
-          </Button>
-          <Button asChild variant="link">
-            <Link to="/signup">Регистрация</Link>
-          </Button>
+        <CardFooter className="flex flex-col items-start space-y-4">
+          <div className="flex flex-row items-center space-x-4 space-y-0">
+            <PendingButton type="submit" form="sign-in-form" isPending={isPending}>
+              Отправить
+            </PendingButton>
+            <Button asChild variant="link">
+              <Link to="/signup">Регистрация</Link>
+            </Button>
+          </div>
+          {isError && (
+            <p className="text-destructive">
+              <ErrorMessage error={error} />
+            </p>
+          )}
         </CardFooter>
       </Card>
     </div>
@@ -42,23 +48,11 @@ export function SignInPage({ redirect }: { redirect: string | undefined }) {
 function ErrorMessage({ error }: { error: Error }) {
   if (error instanceof AxiosError) {
     if (error.response?.status == 401) {
-      return (
-        <p id="signin-card-form-error" className="text-destructive">
-          Неверный логин или пароль
-        </p>
-      );
+      return "Неверный логин или пароль";
     }
     if (error.response?.status == 500) {
-      return (
-        <p id="signin-card-form-error" className="text-destructive">
-          Сервер недоступен
-        </p>
-      );
+      return "Сервер недоступен";
     }
   }
-  return (
-    <p id="signin-card-form-error" className="text-destructive">
-      {error.message}
-    </p>
-  );
+  return error.message;
 }

--- a/frontend/src/pages/signup/ui/signup.tsx
+++ b/frontend/src/pages/signup/ui/signup.tsx
@@ -3,7 +3,7 @@ import { AxiosError } from "axios";
 import { z } from "zod";
 import { SignUpForm, useSignUpByEmailMutation } from "@/features/auth-by-email";
 import { formSchema } from "@/features/auth-by-email";
-import { Button } from "@/shared/ui/button.tsx";
+import { Button, PendingButton } from "@/shared/ui/button.tsx";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/shared/ui/card.tsx";
 
 export function SignUpPage({ redirect }: { redirect: string | undefined }) {
@@ -24,11 +24,17 @@ export function SignUpPage({ redirect }: { redirect: string | undefined }) {
       <CardContent>
         <SignUpForm onSubmit={onSubmit} />
       </CardContent>
-      <CardFooter className="space-x-4">
-        {isError && <ErrorMessage error={error} />}
-        <Button type="submit" form="sign-up-form" disabled={isPending}>
-          Отправить
-        </Button>
+      <CardFooter className="flex flex-col items-start space-y-4">
+        <div className="space-x-4">
+          <PendingButton type="submit" form="sign-up-form" isPending={isPending}>
+            Отправить
+          </PendingButton>
+        </div>
+        {isError && (
+          <p className="text-destructive">
+            <ErrorMessage error={error} />
+          </p>
+        )}
       </CardFooter>
     </Card>
   );
@@ -37,22 +43,10 @@ export function SignUpPage({ redirect }: { redirect: string | undefined }) {
 function ErrorMessage({ error }: { error: Error }) {
   if (error instanceof AxiosError) {
     if (error.response?.status == 409) {
-      return (
-        <p id="signin-card-form-error" className="text-destructive">
-          Пользователь с данной почтой уже существует
-        </p>
-      );
+      return "Пользователь с данной почтой уже существует";
     } else if (error.response?.status == 500) {
-      return (
-        <p id="signin-card-form-error" className="text-destructive">
-          Сервер недоступен
-        </p>
-      );
+      return "Сервер недоступен";
     }
   }
-  return (
-    <p id="signin-card-form-error" className="text-destructive">
-      {error.message}
-    </p>
-  );
+  return error.message;
 }

--- a/frontend/src/pages/signup/ui/signup.tsx
+++ b/frontend/src/pages/signup/ui/signup.tsx
@@ -3,7 +3,7 @@ import { AxiosError } from "axios";
 import { z } from "zod";
 import { SignUpForm, useSignUpByEmailMutation } from "@/features/auth-by-email";
 import { formSchema } from "@/features/auth-by-email";
-import { Button, PendingButton } from "@/shared/ui/button.tsx";
+import { PendingButton } from "@/shared/ui/button.tsx";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/shared/ui/card.tsx";
 
 export function SignUpPage({ redirect }: { redirect: string | undefined }) {

--- a/frontend/src/pages/simulation/ui/index.tsx
+++ b/frontend/src/pages/simulation/ui/index.tsx
@@ -17,7 +17,7 @@ import { GetZoomCoefficientProvider } from "@/features/zoom-provider";
 import { Scheme, getSchemeByIDQueryOptions, useUpdateSchemeMutation } from "@/entities/scheme";
 import { schemaErrors } from "@/shared/simulation/errors";
 import { AlertDialog } from "@/shared/ui/alert-dialog";
-import { Button } from "@/shared/ui/button";
+import { Button, PendingButton } from "@/shared/ui/button";
 import { ResizableHandle, ResizablePanelGroup } from "@/shared/ui/resizable.tsx";
 import { useSimulationState } from "../model/state";
 import { SimulationBlockDialog } from "./block";
@@ -85,13 +85,13 @@ export function Simulation({ mode, setMode, scheme: initialScheme }: Props) {
               <UpdateComponentProvider onUpdateComponent={onUpdateComponent}>
                 <GetMeasurementProvider getCurrentMeasurement={(id: number) => getMeasurementForComponent(id)}>
                   <ResizablePanelGroup direction="horizontal">
-                    <div className="w-60 space-y-8 border-r-4 bg-white p-4">
+                    <div className="space-y-8 border-r-4 bg-white p-4">
                       {mode == "editing" ? (
                         <ComponentChooseBar />
                       ) : (
                         selectedComponent?._type == "rheostat" && <RheostatKnob component={selectedComponent} />
                       )}
-                      <Button
+                      <PendingButton
                         size="icon"
                         className="aspect-square w-full"
                         onClick={() => {
@@ -112,9 +112,8 @@ export function Simulation({ mode, setMode, scheme: initialScheme }: Props) {
                           );
                         }}
                         disabled={isPending || !scheme.canEdit}
-                      >
-                        {isPending ? <RotateCcw className="animate-spin" /> : <Save />}
-                      </Button>
+                        icon={<Save />}
+                      />
                     </div>
                     <ResizableHandle />
                     <CanvasPanel

--- a/frontend/src/pages/simulation/ui/index.tsx
+++ b/frontend/src/pages/simulation/ui/index.tsx
@@ -1,6 +1,6 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
-import { RotateCcw, Save } from "lucide-react";
+import { Save } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { CanvasPanel } from "@/widgets/canvas";
@@ -17,7 +17,7 @@ import { GetZoomCoefficientProvider } from "@/features/zoom-provider";
 import { Scheme, getSchemeByIDQueryOptions, useUpdateSchemeMutation } from "@/entities/scheme";
 import { schemaErrors } from "@/shared/simulation/errors";
 import { AlertDialog } from "@/shared/ui/alert-dialog";
-import { Button, PendingButton } from "@/shared/ui/button";
+import { PendingButton } from "@/shared/ui/button";
 import { ResizableHandle, ResizablePanelGroup } from "@/shared/ui/resizable.tsx";
 import { useSimulationState } from "../model/state";
 import { SimulationBlockDialog } from "./block";

--- a/frontend/src/shared/ui/button.tsx
+++ b/frontend/src/shared/ui/button.tsx
@@ -3,7 +3,7 @@ import { type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../lib";
 import { buttonVariants } from "./button-variants";
-import { RotateCcw } from "lucide-react";
+import { RotateCw } from "lucide-react";
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
@@ -26,7 +26,7 @@ const PendingButton = React.forwardRef<HTMLButtonElement, PendingButtonProps>(
   ({ isPending, disabled, children, ...props }, ref) => {
     return (
       <Button {...props} disabled={disabled || isPending} ref={ref}>
-        {isPending && <RotateCcw className="mr-2 size-4 animate-spin" />}
+        {isPending && <RotateCw className="mr-2 size-4 animate-spin" />}
         {children}
       </Button>
     );

--- a/frontend/src/shared/ui/button.tsx
+++ b/frontend/src/shared/ui/button.tsx
@@ -3,6 +3,7 @@ import { type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../lib";
 import { buttonVariants } from "./button-variants";
+import { RotateCcw } from "lucide-react";
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
@@ -17,4 +18,19 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
-export { Button };
+type PendingButtonProps = Omit<ButtonProps, "asChild"> & {
+  isPending?: boolean;
+};
+
+const PendingButton = React.forwardRef<HTMLButtonElement, PendingButtonProps>(
+  ({ isPending, disabled, children, ...props }, ref) => {
+    return (
+      <Button {...props} disabled={disabled || isPending} ref={ref}>
+        {isPending && <RotateCcw className="mr-2 size-4 animate-spin" />}
+        {children}
+      </Button>
+    );
+  },
+);
+
+export { Button, PendingButton };

--- a/frontend/src/shared/ui/button.tsx
+++ b/frontend/src/shared/ui/button.tsx
@@ -20,13 +20,14 @@ Button.displayName = "Button";
 
 type PendingButtonProps = Omit<ButtonProps, "asChild"> & {
   isPending?: boolean;
+  icon?: React.ReactNode;
 };
 
 const PendingButton = React.forwardRef<HTMLButtonElement, PendingButtonProps>(
-  ({ isPending, disabled, children, ...props }, ref) => {
+  ({ isPending, disabled, children, icon, ...props }, ref) => {
     return (
       <Button {...props} disabled={disabled || isPending} ref={ref}>
-        {isPending && <RotateCw className="mr-2 size-4 animate-spin" />}
+        {isPending ? <RotateCw className="mr-2 size-4 animate-spin" /> : icon}
         {children}
       </Button>
     );


### PR DESCRIPTION
- feat: add `PendingButton` component that shows a spinning arrow when mutation is pending
- feat: regenerate style with oxidus (it was broken previously)
- feat: add `PendingButton` to sign in, sign up, save scheme pages
- fix: layout on sign in, sign up pages
- fix: set component choose width to auto
- fix: show error when user is trying to change their own permissions